### PR TITLE
refactor package-manager with Vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     }
   },
   "panel": {
-    "main": "panel/package-manager.html",
-    "ui": "polymer",
+    "main": "panel/package-manager.js",
     "type": "dockable",
     "title": "Package Manager",
     "icon": "panel/icon.png",

--- a/panel/package-manager.html
+++ b/panel/package-manager.html
@@ -1,60 +1,53 @@
-<dom-module id="package-manager">
-    <link rel="import" type="css" href="package-manager.css">
+<div>
+  <div class='toolbar'>
+    <ui-input v-el:search id='search'
+      unnavigable
+      :value='filterText'
+      placeholder='Search...'
+      @change='_onSearchChange'
+    ></ui-input>
+  </div>
+  <div class='border'>
+    <ul v-if='filterPackages.length > 0' id='view' class='flex-1'>
+        <li class='pkg-item' v-for='item in filterPackages'>
+          <div class='layout horizontal justified name-col'>
+            <a class='name'>{{item.info.name}}</a>
+            <div class='version'>
+              <span>Version: </span>
+              <span>{{item.info.version}}</span>
+            </div>
+          </div>
 
-    <template>
-        <div class="toolbar">
-          <ui-input id="search"
-            unnavigable
-            value="{{filterText::change}}"
-            placeholder="Search... (RegExp)"
-          ></ui-input>
-        </div>
-        <div class="border">
-          <ul id="view" class="flex-1">
-            <template is="dom-repeat" id="list" items="{{_applyFilter(packages,filterText)}}" sort="_sortPackages">
-              <li class="pkg-item">
-                <div class="layout horizontal justified name-col">
-                  <a class="name">{{item.info.name}}</a>
-                  <div class="version">
-                    <span>Version: </span>
-                    <span>{{item.info.version}}</span>
-                  </div>
-                </div>
+          <div class='layout horizontal desc-col'>
+            <span class='desc'>{{item.info.description}}</span>
+          </div>
 
-                <div class="layout horizontal desc-col">
-                  <span class="desc">{{item.info.description}}</span>
-                </div>
+          <div class='layout horizontal author-col'>
+            <span>Author:</span>
+            <span class='author'>{{item.info.author}}</span>
+          </div>
 
-                <div class="layout horizontal author-col">
-                  <span>Author:</span>
-                  <span class="author">{{item.info.author}}</span>
-                </div>
-
-                <div class="layout horizontal btn-col end-justified">
-                  <ui-button class="red" no-focus>
-                    <i class="icon-trash-empty"></i>
-                    <span>Uninstall</span>
-                  </ui-button>
-                  <ui-button no-focus>
-                    <i class="icon-pause"></i>
-                    <span>{{_enabledText(item.enabled)}}</span>
-                  </ui-button>
-                  <ui-button no-focus on-click="_onReload">
-                    <i class="icon-ccw"></i>
-                    <span>Reload</span>
-                  </ui-button>
-                  <ui-button no-focus on-click="_onTest" disabled$="[[!item.hasTests]]">
-                    <span>Test</span>
-                  </ui-button>
-                </div>
-              </li>
-            </template>
-          </ul>
-        </div>
-        <div id="none" hidden>
-            <h1>No Result!</h1>
-        </div>
-    </template>
-
-    <script type="text/javascript" src="package-manager.js"></script>
-</dom-module>
+          <div class='layout horizontal btn-col end-justified'>
+            <!-- <ui-button class='red' no-focus>
+              <i class='icon-trash-empty'></i>
+              <span>Uninstall</span>
+            </ui-button>
+            <ui-button no-focus>
+              <i class='icon-pause'></i>
+              <span>{{_enabledText(item.enabled)}}</span>
+            </ui-button> -->
+            <ui-button no-focus @click='_onReload(item)'>
+              <i class='icon-ccw'></i>
+              <span>Reload</span>
+            </ui-button>
+            <!-- <ui-button no-focus on-click='_onTest' disabled='{{!item.hasTests}}'>
+              <span>Test</span>
+            </ui-button> -->
+          </div>
+        </li>
+    </ul>
+  </div>
+  <div v-if='filterPackages.length === 0' id='none'>
+      <h1>No Result!</h1>
+  </div>
+</div>

--- a/panel/package-manager.js
+++ b/panel/package-manager.js
@@ -1,112 +1,128 @@
-(function () {
-  'use strict';
+const fs = require('fs');
 
-  var _ = require('lodash');
+var _ = require('lodash');
 
-  function _createPackageInfo ( result ) {
-    return {
-      enabled: result.enabled,
-      hasTests: result.info.tests && result.info.tests.length > 0,
-      info: result.info,
-    };
-  }
+function _createPackageInfo(result) {
+  return {
+    enabled: result.enabled,
+    hasTests: result.info.tests && result.info.tests.length > 0,
+    info: result.info,
+  };
+}
 
-  Editor.polymerPanel( 'package-manager', {
-    properties: {
-      filterText: {
-        type: String,
-        value: ''
-      }
+function createVue(elem) {
+  return new window.Vue({
+    el: elem,
+
+    data: {
+      filterText: '',
+      packages: [],
+      filterPackages: [],
     },
 
-    ready: function () {
-      Editor.Package.queryInfos(function ( err, results ) {
-        var packages = results.map( function (item) {
+    compiled() {
+      let self = this;
+      Editor.Package.queryInfos(function (err, results) {
+        var packages = results.map(function (item) {
           return _createPackageInfo(item);
         });
-        this.set( 'packages', packages );
-      }.bind(this));
-    },
-
-    focusOnSearch: function ( event ) {
-      if ( event ) {
-        event.stopPropagation();
-      }
-
-      Editor.UI.focus(this.$.search);
-    },
-
-    messages: {
-      'editor:package-loaded': function ( event, name ) {
-        Editor.Package.queryInfo(name, function ( err, result ) {
-          this.push( 'packages', _createPackageInfo(result));
-        }.bind(this));
-      },
-
-      'editor:package-unloaded': function ( event, name ) {
-        var idx = _.findIndex( this.packages, function ( item ) {
-          return item.info.name === name;
-        });
-        this.splice( 'packages', idx, 1 );
-      },
-    },
-
-    _onReload: function (event) {
-      event.stopPropagation();
-
-      var model = this.$.list.modelForElement(event.target);
-      var oldname = model.item.info.name;
-      Editor.Package.reload(oldname);
-    },
-
-    _onTest: function (event) {
-      event.stopPropagation();
-
-      var item = this.$.list.itemForElement(event.target);
-      Editor.Panel.open( 'tester', {
-        name: item.info.name,
+        self.packages = packages;
+        self._applyFilter();
       });
     },
 
-    _enabledText: function (enabled) {
-      if (enabled) {
-        return 'Disable';
-      }
-      else {
-        return 'Enable';
-      }
-    },
-
-    _sortPackages: function ( a, b ) {
-      return a.info.name.localeCompare( b.info.name );
-    },
-
-    _applyFilter: function (packages,filterText) {
-      if (!filterText) {
-        this.$.view.hidden = false;
-        this.$.none.hidden = true;
-
-        return packages;
-      }
-
-      var tmpPackages = [];
-      var filter = filterText.toLowerCase();
-      for (var i = 0; i < packages.length; ++i) {
-        if (packages[i].info.name.toLowerCase().match(filter)) {
-          tmpPackages.push(packages[i]);
+    methods: {
+      focusOnSearch (event) {
+        if (event) {
+          event.stopPropagation();
         }
-      }
-      if (tmpPackages.length > 0) {
-        this.$.view.hidden = false;
-        this.$.none.hidden = true;
-      }
-      else {
-        this.$.view.hidden = true;
-        this.$.none.hidden = false;
-      }
 
-      return tmpPackages;
+        Editor.UI.focus(this.$els.search);
+      },
+
+      _onReload (item) {
+        let pkgName = item.info.name;
+        Editor.Package.reload(pkgName);
+      },
+
+      _onTest (event) {
+        event.stopPropagation();
+
+        // var item = this.$els.list.itemForElement(event.target);
+        // Editor.Panel.open('tester', {
+        //   name: item.info.name,
+        // });
+
+        // TODO
+      },
+
+      _enabledText (enabled) {
+        if (enabled) {
+          return 'Disable';
+        }
+        else {
+          return 'Enable';
+        }
+      },
+
+      _sortPackages (a, b) {
+        return a.info.name.localeCompare(b.info.name);
+      },
+
+      _applyFilter () {
+        let packages = this.packages;
+        let filterText = this.filterText;
+
+        if (!filterText) {
+          // 更新过滤后的包列表
+          this.filterPackages = packages;
+          return;
+        }
+
+        var tmpPackages = [];
+        var filter = filterText.toLowerCase();
+        for (var i = 0; i < packages.length; ++i) {
+          if (packages[i].info.name.toLowerCase().match(filter)) {
+            tmpPackages.push(packages[i]);
+          }
+        }
+
+        // 更新过滤后的包列表
+        this.filterPackages = tmpPackages;
+        return;
+      },
+
+      _onSearchChange (event) {
+        let value = event.target.value;
+        this.filterText = value;
+        this._applyFilter();
+      },
     },
   });
+}
 
-})();
+Editor.Panel.extend({
+  template: fs.readFileSync(Editor.url('packages://package-manager/panel/package-manager.html'), 'utf8'),
+
+  style: fs.readFileSync(Editor.url('packages://package-manager/panel/package-manager.css'), 'utf8'),
+
+  ready() {
+    this._vm = createVue(this.shadowRoot);
+  },
+
+  messages: {
+    'editor:package-loaded' ( event, name ) {
+      let self = this;
+      Editor.Package.queryInfo(name, function ( err, result ) {
+        self._vm.packages.push(_createPackageInfo(result));
+      });
+    },
+
+    'editor:package-unloaded' ( event, name ) {
+      var idx = _.findIndex( this.packages, function ( item ) {
+        return item.info.name === name;
+      });
+      this._vm.packages.splice(idx, 1);
+    },
+  },
+});


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/296
用 Vue 重写 package-manager

禁用了 uninstall disable test按钮 

重写前：
<img width="497" alt="WechatIMG31" src="https://user-images.githubusercontent.com/17872773/57366451-912c5180-71b9-11e9-8f5d-8dab67570b67.png">
重写后：
<img width="492" alt="WechatIMG30" src="https://user-images.githubusercontent.com/17872773/57366471-99848c80-71b9-11e9-82d4-106517f49943.png">
